### PR TITLE
Fix for multiQC output change to support GCS work dir

### DIFF
--- a/kallisto.nf
+++ b/kallisto.nf
@@ -189,7 +189,7 @@ process multiqc {
 
     output:
     file "*multiqc_report.html" into multiqc_report
-    file "*_data"
+    file "*_data/*"
 
     script:
     rtitle = "--title \"lifebit-ai/kallisto-nf\""


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lifebit-ai/kallisto-nf/3)
<!-- Reviewable:end -->

The way the output channel was previously defined failed in a google cloud pipeline using a GCS bucket as work-dir:

```
ERROR ~ Error executing process > 'multiqc'

Caused by:
  Missing output file(s) `*_data` expected by process `multiqc`

Command executed:

  multiqc . -f --title "lifebit-ai/kallisto-nf" --filename multiqc_report --config multiqc_config.yaml \
      -m custom_content -m kallisto

Command exit status:
  0

Command output:
  (empty)

Command error:
  [INFO   ]         multiqc : This is MultiQC v0.9
  [INFO   ]         multiqc : Template    : default
  [INFO   ]         multiqc : Report title: lifebit-ai/kallisto-nf
  [INFO   ]         multiqc : Searching '.'
  [INFO   ]         multiqc : Only using modules custom_content, kallisto
  [INFO   ]        kallisto : Found 6 reports
  [INFO   ]         multiqc : Report      : multiqc_report.html
  [INFO   ]         multiqc : Data        : multiqc_report_data
  [INFO   ]         multiqc : MultiQC complete

Work dir:
  gs://nf-work-test/kallisto-n1-2/15/5880d10fa3544f71cfb248763649ff

Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`

 -- Check '.nextflow.log' file for details

```

Even though the *_data directory exists in the bucket. Seems like this is an issue of how NF matches the file regex against the GCS storage provider.

The proposed change fixes that issue, allowing the job to run on GCP with GCS work dir while keeping the same functionality, hopefully. 